### PR TITLE
Bug: Fix for failed cli based queries if a transaction is not active

### DIFF
--- a/lib/Cake/Model/Datasource/DboSource.php
+++ b/lib/Cake/Model/Datasource/DboSource.php
@@ -2462,6 +2462,12 @@ class DboSource extends DataSource {
 				$this->took = $this->numRows = $this->affected = false;
 				$this->logQuery('COMMIT');
 			}
+
+			if (!$this->_connection->inTransaction()) {
+				error_log('Commit failed: Transaction is not active');
+				return false;
+			}
+
 			$this->_transactionStarted = false;
 			return $this->_connection->commit();
 		}
@@ -3270,13 +3276,14 @@ class DboSource extends DataSource {
 		}
 		$sign = isset($result[3]);
 
+		if ($length === null) {
+			// prevent deprecation warnings
+			return null;
+		}
+
 		$isFloat = in_array($type, array('dec', 'decimal', 'float', 'numeric', 'double'));
 		if ($isFloat && strpos($length, ',') !== false) {
 			return $length;
-		}
-
-		if ($length === null) {
-			return null;
 		}
 
 		if (isset($types[$type])) {


### PR DESCRIPTION
This fixes a bug found during a migration run where the query would fail due to no active PDO transaction. The change forces it to return false if a transaction does not exist for the query. This in turn creates a new transaction and allows the query to proceed.

A minor tweak to relocate an if statement has also been added to prevent deprecation warnings on PHP 8.x